### PR TITLE
Add `update-major-version` CI workflow.

### DIFF
--- a/.github/workflows/update-major-version.yaml
+++ b/.github/workflows/update-major-version.yaml
@@ -1,0 +1,12 @@
+name: update-major-version
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  update-major-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1


### PR DESCRIPTION
This will update the major version tag when a new release is tagged, making it easier to consume the action downstream as `@v1` instead of `@v1.2.3` or whatever.